### PR TITLE
Incorrect PANEL_CLAIM_AN_AUTORSHIP_FEATURE_DESC translation key

### DIFF
--- a/frontend/app/views/claimauthorship.html
+++ b/frontend/app/views/claimauthorship.html
@@ -9,7 +9,7 @@
       </div>
    </md-toolbar>
    <div>
-      <h3 translate="PANEL_CLAIM_AN_AUTORSHIP_FEATURE_DESC"></h3>
+      <h3 translate="PANEL_CLAIM_AN_AUTHORSHIP_FEATURE_DESC"></h3>
       <p class="explanations" translate="PANEL_CLAIM_AN_AUTHORSHIP_FEATURE_DESC2"></p>
       <form ng-submit="claim()">
          <md-input-container>


### PR DESCRIPTION
This PR is for using the correct `PANEL_CLAIM_AN_AUTHORSHIP_FEATURE_DESC` translation key in the authorship claiming page.