### PR TITLE
Fix multiple tags with same name

### DIFF
--- a/api/src/endpoints/Tags.php
+++ b/api/src/endpoints/Tags.php
@@ -62,8 +62,8 @@ $tag_single = Tool::makeEndpoint(function($key) use($app) {
 $tag_plugins = Tool::makeEndpoint(function($key) use($app) {
    OAuthHelper::needsScopes(['tag', 'plugins']);
 
-   $tag = Tag::where('key', '=', $key)->first();
-   if ($tag == NULL) {
+   $tags = Tag::where('key', '=', $key)->get();
+   if ($tags->isEmpty()) {
       throw new \API\Exception\ResourceNotFound('Tag', $key);
    }
 
@@ -71,7 +71,7 @@ $tag_plugins = Tool::makeEndpoint(function($key) use($app) {
                 ->short()
                 ->withAverageNote()
                 ->descWithLang(Tool::getRequestLang())
-                ->withTag($tag));
+                ->withTags($tags));
    Tool::endWithJson($plugins);
 });
 

--- a/api/src/models/Plugin.php
+++ b/api/src/models/Plugin.php
@@ -129,10 +129,14 @@ class Plugin extends Model {
       return $query;
    }
 
-   public function scopeWithTag($query, $tag) {
+   public function scopeWithTags($query, $tags) {
+      $ids = $tags->map(function ($tag) {
+         return $tag->id;
+      });
+
       $query->join('plugin_tags', 'plugin.id', '=', 'plugin_tags.plugin_id')
          ->join('tag', 'plugin_tags.tag_id', '=', 'tag.id')
-         ->where('tag.id', '=', $tag->id);
+         ->whereIn('tag.id', $ids);
       return $query;
    }
 
@@ -166,7 +170,7 @@ class Plugin extends Model {
 
    /**
     * Will increment the fetch fails counter,
-    * or initialize it if no 
+    * or initialize it if no
     */
    public function incrementXmlFetchFailCount() {
       if (!$this->id) {


### PR DESCRIPTION
Requests on  `api/tag/XXXX/plugin` use the first matching tag despite the fact that we may have multiple tags with the same name.

For example, we have two tickets tags but the API will only return the plugins associated to the first one.
![image](https://user-images.githubusercontent.com/42734840/96102446-d2f51780-0ed6-11eb-94bb-39b5ce38ab7d.png)
![image](https://user-images.githubusercontent.com/42734840/96102555-f15b1300-0ed6-11eb-8538-5ad8f3828c56.png)

These changes use all matching tags instead.


