### PR TITLE
Fix latest version in plugin's page and RSS feed

### DIFF
--- a/api/src/core/Tool.php
+++ b/api/src/core/Tool.php
@@ -87,6 +87,7 @@ class Tool {
                   ->first();
 
          if ($plugin) {
+            $last_version = $plugin->getLatestVersion();
             $plugin = $plugin->toArray();
 
             // compute date
@@ -110,8 +111,8 @@ class Tool {
 
             // find last version (the first in list)
             $version_num  = $version_compat = "";
-            $last_version = array_shift($plugin['versions']);
             if ($last_version != NULL) {
+               $last_version = $last_version->toArray();
                $version_num    = $last_version['num'];
                $version_compat = $last_version['compatibility'];
                $description.=  "<br />

--- a/api/src/models/Plugin.php
+++ b/api/src/models/Plugin.php
@@ -217,4 +217,9 @@ class Plugin extends Model {
         ->delete();
       return 0;
    }
+
+   public function getLatestVersion() {
+      $sorted = $this->versions->sortByDesc('num', SORT_NATURAL);
+      return $sorted->first();
+   }
 }

--- a/frontend/app/index.html
+++ b/frontend/app/index.html
@@ -152,6 +152,7 @@
       <script src="scripts/controllers/tags.js"></script>
       <script src="scripts/controllers/version.js"></script>
       <script src="scripts/services/fixindepnet.js"></script>
+      <script src="scripts/services/pluginversions.js"></script>
       <script src="scripts/controllers/signup.js"></script>
       <script src="scripts/directives/usermenu.js"></script>
       <script src="scripts/controllers/panel.js"></script>

--- a/frontend/app/scripts/controllers/plugin.js
+++ b/frontend/app/scripts/controllers/plugin.js
@@ -11,7 +11,7 @@ angular.module('frontendApp')
 
 .controller('PluginCtrl', function(API_URL, $scope, $http, $stateParams,
                                    $window, $filter, $state, $mdToast,
-                                   $timeout, fixIndepnet, Toaster) {
+                                   $timeout, fixIndepnet, Toaster, PluginVersions) {
    $scope.plugin = {
       authors: {},
       download_count: 0
@@ -160,6 +160,7 @@ angular.module('frontendApp')
    .success(function(data) {
       fixIndepnet.fix(data);
       $scope.plugin = data;
+      $scope.plugin.versions = PluginVersions.sort(data.versions);
       $scope.rated = (localStorage.getItem('rated_' + $scope.plugin.id) == 'true') ? true : false;
       $scope.selectedIndex = getTabWithLang(localStorage.getItem('lang'));
 

--- a/frontend/app/scripts/services/pluginversions.js
+++ b/frontend/app/scripts/services/pluginversions.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * @ngdoc service
+ * @name glpiPluginDirectoryMasterApp.PluginVersions
+ * @description
+ * # PluginVersions
+ * Service in the glpiPluginDirectoryMasterApp.
+ */
+angular.module('frontendApp')
+   .provider('PluginVersions', function () {
+      var PluginVersions = function() {};
+      
+      PluginVersions.prototype.sort = function(versions) {
+         return versions.sort(function(a, b) {
+            return b.num.localeCompare(a.num, undefined, {
+               numeric: true,
+               sensitivity: 'base'
+            });
+         });
+      };
+
+      this.$get = function () {
+         return new PluginVersions();
+      };
+   });


### PR DESCRIPTION
Versions returned by Eloquent model are sorted by `num` field by MySQL. Unfortunately, MySQL does not provide natural sorting feature, and result is not always as expected (e.g. `2.9.5` > `2.10.1`).

As it is not possible to automatically do a custom sorting when model data is fetched, I had to implement a sort function both on RSS response building and on Angular controller.