### PR TITLE
Permit usage of more HTML tags in plugins descriptions

### DIFF
--- a/api/src/core/BackgroundTasks.php
+++ b/api/src/core/BackgroundTasks.php
@@ -630,7 +630,11 @@ class BackgroundTasks {
     * @return string
     */
    private function sanitizeHtml(string $html): string {
-      $sanitizer = Sanitizer::create(['extensions' => ['basic']]);
+      $sanitizer = Sanitizer::create(
+          [
+              'extensions' => ['basic', 'code', 'details', 'extra', 'list', 'table',]
+          ]
+      );
       return $sanitizer->sanitize($html);
    }
 


### PR DESCRIPTION
Some plugins are using HTML tags that are currently removed by sanitize process, even if they cannot be used for XSS purpose.

Removal of these tags combined with markdown transformation may lead to unexpected double encoding of HTML special chars ( see https://plugins.glpi-project.org/#/plugin/escalation ).

With this change, almost all HTML tags are allowed, except thoose that can be used to load external resources (img, video, object, iframe, ...).