### PR TITLE
Handle callback to http in Oauth authentication

### DIFF
--- a/frontend/app/scripts/services/auth.js
+++ b/frontend/app/scripts/services/auth.js
@@ -124,7 +124,7 @@ angular.module('frontendApp')
 
          try {
             var location = authorizationRequestWindow.location.href;
-            if (location.split(API_URL).length > 1) {
+            if (location.split(API_URL.replace(/http(s)?:/, '')).length > 1) {
                var evl = authorizationRequestWindow.addEventListener('message', function(e) {
                   var data = JSON.parse(e.data);
                   if (!data.error) {


### PR DESCRIPTION
The oauth authentication process uses a `window.postMessage()` that is handled by a `message` event listener.
Problem is that this listener is currently defined only if callback URL (`http://plugins.glpi-project.org/api/oauth/associate/github`) is contained inside API_URL (`https://plugins.glpi-project.org/api/`). On URL is using http while the other is using https, so check does not match anymore.

I guess this condition has been made to prevent the listener to triggered from another `message` event. Trimming protocol in the check should fix this issue.